### PR TITLE
Looking for valid postalCode but keeping compatibility with other countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check if `postalCode` has asterix(`*`) instead of `isNaN`
+
 ## [0.2.3] - 2020-10-07
 
 ### Fixed

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-console */
 import React, { useEffect } from 'react'
 import {
   injectIntl,
@@ -244,7 +243,7 @@ const AvailabilitySummary: StorefrontFunctionComponent<
     if (
       !!hasShipping?.address?.postalCode &&
       // eslint-disable-next-line no-restricted-globals
-      !isNaN(hasShipping.address.postalCode) &&
+      hasShipping.address.postalCode.indexOf('*') === -1 &&
       product &&
       (!prev[product.productId] ||
         prev[product.productId] !== selectedItem.itemId)


### PR DESCRIPTION
#### What does this PR do? \*
Fixes an issue on countries that uses alphanumeric `postalCode`

#### How to test it? \*

Use a valid Canadian postal code, it should show the availability on the products
[Workspace](https://vysk--drinkrunnr.myvtex.com/Beer---Cider/Ale)

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
