### PR TITLE
Remove previous product reference on use effect clean up function in AvailabilitySummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Availability summary, remove previous reference on useEffect cleanup function
+
 ## [0.2.4] - 2021-01-08
 
 ### Fixed

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -51,8 +51,10 @@ const AvailabilitySummary: StorefrontFunctionComponent<
     window.addEventListener('locationUpdated', handleLocationUpdated)
 
     return () => {
-      if(Object.keys(prev).length !== 0){
-        Object.keys(prev).forEach(function(key) { delete prev[key]; });
+      if (Object.keys(prev).length !== 0) {
+        Object.keys(prev).forEach(function(key) { 
+          delete prev[key]
+        });
       }
       window.removeEventListener('locationUpdated', handleLocationUpdated)
     }

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -51,6 +51,9 @@ const AvailabilitySummary: StorefrontFunctionComponent<
     window.addEventListener('locationUpdated', handleLocationUpdated)
 
     return () => {
+      if(Object.keys(prev).length !== 0){
+        Object.keys(prev).forEach(function(key) { delete prev[key]; });
+      }
       window.removeEventListener('locationUpdated', handleLocationUpdated)
     }
   }, [refetch])

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -52,7 +52,7 @@ const AvailabilitySummary: StorefrontFunctionComponent<
 
     return () => {
       if (Object.keys(prev).length !== 0) {
-        Object.keys(prev).forEach(function(key) {
+        Object.keys(prev).forEach(function (key) {
           delete prev[key]
         })
       }

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -52,9 +52,9 @@ const AvailabilitySummary: StorefrontFunctionComponent<
 
     return () => {
       if (Object.keys(prev).length !== 0) {
-        Object.keys(prev).forEach(function(key) { 
+        Object.keys(prev).forEach(function(key) {
           delete prev[key]
-        });
+        })
       }
       window.removeEventListener('locationUpdated', handleLocationUpdated)
     }


### PR DESCRIPTION
AvailabilitySummary component keeps previous product reference to avoid infinite rerendering. But when we use `product-location-availability` in quick view popup it prevents loading shipping info more than one time we open the same quickview item. 

Previous product reference should be cleanup on cleanup function.

#### What does this PR do? \*

Prevent the blocking of `product-location-availability` in quick view.

#### How to test it? \*

You can check this [workspace](https://clouda--eriksbikeshop.myvtex.com/cycling/hydration---food/bottle-cages) 
