### PR TITLE
[USAAPPTEAM-32] Address info added to the component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+### Added 
+- Add `pickupZipCode`
+- Add `showAddressInFo` prop
 
 ## [0.3.0] - 2021-09-15
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,12 +32,13 @@ Now, you are able to use the blocks exported by the `location-availability` app:
 
 This block summarizes a product's availability and is best used on product shelves. By default it will show the two fastest shipping options (or one shipping option and the fastest in-store pickup option). Alternative configurations are available using the props below:
 
-| Prop name      | Type      | Description                                                   | Default value |
-|----------------|-----------|---------------------------------------------------------------|---------------|
-| `maxItems`     | `number`  | Maximum number of availability options shown per product      | `2`           |
-| `orderBy`      | `enum`    | Sort the availability options by `faster` or `cheaper`        | `faster`      |
-| `pickupFirst`  | `boolean` | If available, show in-store pickup before other options       | `true`        |
-| `showDistance` | `string`  | Add the necessary measurement options `kilometers` or `miles` | `miles`       |
+| Prop name         | Type      | Description                                                   | Default value |
+|-------------------|-----------|---------------------------------------------------------------|---------------|
+| `maxItems`        | `number`  | Maximum number of availability options shown per product      | `2`           |
+| `orderBy`         | `enum`    | Sort the availability options by `faster` or `cheaper`        | `faster`      |
+| `pickupFirst`     | `boolean` | If available, show in-store pickup before other options       | `true`        |
+| `showDistance`    | `string`  | Add the necessary measurement options `kilometers` or `miles` | `miles`       |
+| `showAddressInfo` | `boolean` | Adds address ZipCode and city                                 | `false`       |
 
 **Example**
 
@@ -57,7 +58,8 @@ This block summarizes a product's availability and is best used on product shelv
 +      "maxItems": 3
 +      "orderBy": "cheaper"
 +      "pickupFirst": false,
-+      "showDistance": "miles"
++      "showDistance": "miles",
++      "showAddressInfo": true
 +    }
 +  }
 ...

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -37,11 +37,19 @@ interface CheckAvailabilityProps {
   orderBy: string
   pickupFirst: boolean
   showDistance?: string
+  showAddressInfo?: boolean
 }
 
 const AvailabilitySummary: StorefrontFunctionComponent<
   WrappedComponentProps & CheckAvailabilityProps
-> = ({ intl, maxItems, orderBy, pickupFirst, showDistance }: any) => {
+> = ({
+  intl,
+  maxItems,
+  orderBy,
+  pickupFirst,
+  showDistance,
+  showAddressInfo,
+}: any) => {
   const [getSimulation, { data, loading }] = useLazyQuery(SIMULATE)
   const { data: orderFormData, refetch } = useQuery(ORDERFORM, { ssr: false })
 
@@ -97,9 +105,12 @@ const AvailabilitySummary: StorefrontFunctionComponent<
           price: option.price,
           isPickup: !!option.pickupStoreInfo.address,
           storeName: option.pickupStoreInfo.friendlyName,
+          storeZipCode: option.pickupStoreInfo.address.postalCode,
+          storeCity: option.pickupStoreInfo.address.city,
           days: parseInt(option.shippingEstimate.replace(/\D/g, ''), 10),
           distance: option.pickupDistance,
           showDistance,
+          showAddressInfo,
         }
       })
       .sort((a: any, b: any) => {
@@ -152,6 +163,40 @@ const AvailabilitySummary: StorefrontFunctionComponent<
         >
           {option.isPickup && (
             <span className={`${styles.pickUp}`}>
+              {option.showDistance ? (
+                option.distance != null ? (
+                  <div className={styles.addressDistanceContainer}>
+                    {option.showAddressInfo ? (
+                      <span className={styles.addressCity}>
+                        {option.storeCity}{' '}
+                        <span className={styles.addressZip}>
+                          {option.storeZipCode}
+                        </span>
+                      </span>
+                    ) : (
+                      ''
+                    )}
+                    <span className={styles.distance}>
+                      <FormattedMessage id="store/location-availability.distance.title" />{' '}
+                      <span className={styles.distanceEstimate}>
+                        {option.mesurements === 'kilometers'
+                          ? option.distance
+                          : (option.distance * kmToMile).toFixed(1)}
+                        {option.showDistance === 'miles' ? (
+                          <FormattedMessage id="store/location-availability.distance.miles" />
+                        ) : (
+                          <FormattedMessage id="store/location-availability.distance.kilometers" />
+                        )}{' '}
+                        <FormattedMessage id="store/location-availability.distance.away" />
+                      </span>
+                    </span>
+                  </div>
+                ) : (
+                  ''
+                )
+              ) : (
+                ''
+              )}
               <span className={`${styles.pickUpLabel}`}>
                 <FormattedMessage id="store/location-availability.store-pickup-label" />
               </span>{' '}
@@ -219,20 +264,32 @@ const AvailabilitySummary: StorefrontFunctionComponent<
             >
               {option.showDistance ? (
                 option.distance != null ? (
-                  <span className={styles.distance}>
-                    <FormattedMessage id="store/location-availability.distance.title" />{' '}
-                    <span className={styles.distanceEstimate}>
-                      {option.mesurements === 'kilometers'
-                        ? option.distance
-                        : option.distance * kmToMile}{' '}
-                    </span>
-                    {option.showDistance === 'miles' ? (
-                      <FormattedMessage id="store/location-availability.distance.miles" />
+                  <div className={styles.addressDistanceContainer}>
+                    {option.showAddressInfo ? (
+                      <span className={styles.addressCity}>
+                        {option.storeCity}{' '}
+                        <span className={styles.addressZip}>
+                          {option.storeZipCode}
+                        </span>
+                      </span>
                     ) : (
-                      <FormattedMessage id="store/location-availability.distance.kilometers" />
-                    )}{' '}
-                    <FormattedMessage id="store/location-availability.distance.away" />
-                  </span>
+                      ''
+                    )}
+                    <span className={styles.distance}>
+                      <FormattedMessage id="store/location-availability.distance.title" />{' '}
+                      <span className={styles.distanceEstimate}>
+                        {option.mesurements === 'kilometers'
+                          ? option.distance
+                          : (option.distance * kmToMile).toFixed(1)}
+                        {option.showDistance === 'miles' ? (
+                          <FormattedMessage id="store/location-availability.distance.miles" />
+                        ) : (
+                          <FormattedMessage id="store/location-availability.distance.kilometers" />
+                        )}{' '}
+                        <FormattedMessage id="store/location-availability.distance.away" />
+                      </span>
+                    </span>
+                  </div>
                 ) : (
                   ''
                 )

--- a/react/styles.css
+++ b/react/styles.css
@@ -36,8 +36,18 @@
 .distance {
   display: block;
   font-weight: 600;
+  width: 50%;
 }
-
 .distanceEstimate {
-  font-weight: 600;
+  font-weight: 400;
+  display: block;
+}
+.addressDistanceContainer {
+  display: flex;
+}
+.addressCity {
+  width: 50%;
+}
+.addressZip {
+  display: block;
 }


### PR DESCRIPTION
#### What does this PR do? \*
- Add new prop to the component in order to show the address info
- City and Zip code is being shown

#### How to test it? \*
In your environment set a pickup point and add the prop `showAddressInfo`
or 
[Here](https://beto--ektguatemala.myvtex.com/electronica)


## Screenshot of changes:
![Image 2021-10-03 at 12 56 48 p m](https://user-images.githubusercontent.com/11176519/135765789-14e1761e-22a3-4549-a52a-ac65ca31ccb3.jpg)