### PR TITLE
[USAAPPTEAM-157] bugfix postalCode null value and lat long toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- Fix availability map function add default value when empty
+- Fix issue in PDP when geolocation lat long is empty
 ### Added 
 - Add `pickupZipCode`
 - Add `showAddressInFo` prop

--- a/react/AvailabilitySummary.tsx
+++ b/react/AvailabilitySummary.tsx
@@ -105,8 +105,12 @@ const AvailabilitySummary: StorefrontFunctionComponent<
           price: option.price,
           isPickup: !!option.pickupStoreInfo.address,
           storeName: option.pickupStoreInfo.friendlyName,
-          storeZipCode: option.pickupStoreInfo.address.postalCode,
-          storeCity: option.pickupStoreInfo.address.city,
+          storeZipCode: option.pickupStoreInfo.address
+            ? option.pickupStoreInfo.address.postalCode
+            : null,
+          storeCity: option.pickupStoreInfo.address
+            ? option.pickupStoreInfo.address.city
+            : null,
           days: parseInt(option.shippingEstimate.replace(/\D/g, ''), 10),
           distance: option.pickupDistance,
           showDistance,
@@ -181,7 +185,7 @@ const AvailabilitySummary: StorefrontFunctionComponent<
                       <span className={styles.distanceEstimate}>
                         {option.mesurements === 'kilometers'
                           ? option.distance
-                          : (option.distance * kmToMile).toFixed(1)}
+                          : `${(option.distance * kmToMile).toFixed(1)} `}
                         {option.showDistance === 'miles' ? (
                           <FormattedMessage id="store/location-availability.distance.miles" />
                         ) : (
@@ -280,7 +284,7 @@ const AvailabilitySummary: StorefrontFunctionComponent<
                       <span className={styles.distanceEstimate}>
                         {option.mesurements === 'kilometers'
                           ? option.distance
-                          : (option.distance * kmToMile).toFixed(1)}
+                          : `${(option.distance * kmToMile).toFixed(1)} `}
                         {option.showDistance === 'miles' ? (
                           <FormattedMessage id="store/location-availability.distance.miles" />
                         ) : (

--- a/react/LocationQuery.tsx
+++ b/react/LocationQuery.tsx
@@ -109,8 +109,10 @@ const LocationQueryInner: FunctionComponent = ({ children }) => {
         location: {
           postalCode,
           country,
-          lat: geoCoordinates[1].toString(),
-          long: geoCoordinates[0].toString(),
+          lat:
+            geoCoordinates.length !== 0 ? geoCoordinates[1].toString() : null,
+          long:
+            geoCoordinates.length !== 0 ? geoCoordinates[0].toString() : null,
         },
       },
     })


### PR DESCRIPTION
## Description
- When the app maps through each one of the `slas`, not all the slas have a `zipcode` this causes it to break

#### What does this PR do? \*
- Add default value if no address was available in the `sla`
- Add default value if `lat long` is not available
- Fixes this issue https://vtex-dev.atlassian.net/browse/USAAPPTEAM-157

#### How to test it? \*
Testing can be done [Here](https://beto--eriksbikeshop.myvtex.com/cycling)

## Screenshot of changes
PLP:
![Image 2021-10-05 at 12 21 10 a m](https://user-images.githubusercontent.com/11176519/135964819-bbebe9fe-0cbe-4394-907d-075b2cbcdf1a.jpg)

PDP:
![Image 2021-10-05 at 12 21 50 a m](https://user-images.githubusercontent.com/11176519/135964895-aed5a666-2080-4586-b86c-1cf507b6a11c.jpg)
![Image 2021-10-05 at 12 23 32 a m](https://user-images.githubusercontent.com/11176519/135965090-4c46bf4c-187d-4a43-8eb8-a75db5b9a46d.jpg)




